### PR TITLE
CI for pdf release

### DIFF
--- a/.github/workflows/generate_release_pdf.yml
+++ b/.github/workflows/generate_release_pdf.yml
@@ -1,0 +1,89 @@
+name: Generate Release PDF
+
+on: 
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.gitignore'
+      - '**.md'
+
+env:
+  TYPST_FILE_NAME: book
+  TYPST_FONT_PATH: fonts
+
+jobs:
+  build_typst:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up Git repository for secondary repo
+        uses: actions/checkout@v4
+
+      - name: Cache Fonts
+        uses: actions/cache@v4
+        id: cache-fonts
+        with:
+          path: fonts
+          key: ${{ runner.os }}-fonts-noto_sans_sc
+
+      - name: Download Fonts
+        if: steps.cache-fonts.outputs.cache-hit != 'true'
+        run: |
+          if [ -f "${{ env.TYPST_FONT_PATH }}/NotoSansSC-Regular.ttf" ]; then
+            echo "Font already existed."
+          else
+            # Download font metadata
+            mkdir -p cv
+            curl -s "https://fonts.google.com/download/list?family=Noto%20Sans%20SC" > cv/noto_sans_sc_raw.txt
+
+            # Remove ")]}'" from the beginning of the file
+            tail -c +5 cv/noto_sans_sc_raw.txt > cv/noto_sans_sc_metadata.json
+
+            # Extract the necessary information from the JSON file
+            file_refs=$(jq -rc '.manifest.fileRefs[]' cv/noto_sans_sc_metadata.json)
+
+            # Download, save the font file to /fonts
+            mkdir -p ${{ env.TYPST_FONT_PATH }}
+            while IFS= read -r file_ref; do
+                filename=$(echo "$file_ref" | jq -r '.filename')
+                url=$(echo "$file_ref" | jq -r '.url')
+                fontname=$(basename "$filename")
+                echo $url $fontname
+                curl "$url" -o "${{ env.TYPST_FONT_PATH }}/$fontname"
+            done <<< "$file_refs"
+            ls -l ${{ env.TYPST_FONT_PATH }}
+          fi
+
+      - name: Prepare Typst environment
+        uses: typst-community/setup-typst@v3
+
+      - name: Compile Typst document
+        run: |
+          typst fonts --variants --font-path ${{ env.TYPST_FONT_PATH }}
+          typst compile ${{ env.TYPST_FILE_NAME }}.typ ${{ env.TYPST_FILE_NAME }}.pdf --font-path ${{ env.TYPST_FONT_PATH }}
+
+      - name: Delete old Release
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo
+            try {
+              const { data: { id } } = await github.rest.repos.getLatestRelease({ owner, repo })
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
+            } catch {}
+
+      - name: Generate release tag
+        id: tag
+        run: |
+          echo "::set-output name=release_tag::latest_$(date +"%Y-%m-%d_%H-%M")"
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: latest version
+          body: Latest version of `${{ env.TYPST_FILE_NAME }}.pdf`
+          tag_name: ${{ steps.tag.outputs.release_tag }}
+          files: ${{ env.TYPST_FILE_NAME }}.pdf

--- a/.github/workflows/generate_release_pdf.yml
+++ b/.github/workflows/generate_release_pdf.yml
@@ -55,6 +55,9 @@ jobs:
             done <<< "$file_refs"
             ls -l ${{ env.TYPST_FONT_PATH }}
           fi
+          for form in Light Regular Bold; do
+              curl -sSL "https://github.com/lxgw/LxgwWenKai/releases/download/v1.330/LXGWWenKai-$form.ttf" -o "${{ env.TYPST_FONT_PATH }}/LXGWWenKai-$form.ttf"
+          done
 
       - name: Prepare Typst environment
         uses: typst-community/setup-typst@v3


### PR DESCRIPTION
为 [cppguidebook](https://github.com/parallel101/cppguidebook) 添加CI. 

目前CI的行为是我平时习惯的设置：所有push到main的commit会将`book.typ`编译为`book.pdf`，然后删除旧的Release，将其替换为新的`book.pdf`，生成的下载链接为 https://github.com/parallel101/cppguidebook/releases/latest/download/book.pdf. 可以根据具体需求继续修改，比如push时显式添加tag才会触发CI。

typst的字体有时会有谜之fallback机制，我习惯通过`--font-path`显式指定最高优先级的字体文件夹，通常是`/fonts`。目前`book.typ`使用了非默认字体族 NotoSansSC ，CI初次运行会自动下载字体文件到`/fonts`文件夹下，之后`/fonts`文件夹会被缓存. 