### PR TITLE
更正 design_gamedev.md 中的不完整类型导致的错误

### DIFF
--- a/docs/design_gamedev.md
+++ b/docs/design_gamedev.md
@@ -77,8 +77,10 @@ private:
     Game() { ... }
 
 public:
-    inline static Game instance;  // 如果定义在头文件中，需要 inline！
+    static Game instance;  // 非定义声明，因为 Game 在此处为不完整类型
 };
+
+inline Game Game::instance;  // 如果定义在头文件中，需要 inline！
 
 Game::instance.updatePlayers();
 ```

--- a/docs/design_gamedev.md
+++ b/docs/design_gamedev.md
@@ -77,7 +77,8 @@ private:
     Game() { ... }
 
 public:
-    static Game instance;  // 非定义声明，因为 Game 在此处为不完整类型
+    // inline static Game instance;  // 虽然很爽，但不能这样写，因为 Game 在他的 }; 结束前都是不完整类型
+    static Game instance;  // 非定义声明，就好比全局变量的 extern Game instance 一样，不需要是完整类型
 };
 
 inline Game Game::instance;  // 如果定义在头文件中，需要 inline！


### PR DESCRIPTION
如果某个类需要有一个类型为它自身的 static 成员，则在类体内的成员声明不能是定义，因为此处不是完整类语境。

Fixes #21.