### PR TITLE
更正 index.md 中缺失 `static` 的 `constexpr` 成员变量

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,12 +98,12 @@ void try_call_foo(T &t) {
 ```cpp
 template <class T, class = void>
 struct has_foo {
-    inline constexpr bool value = false;
+    static constexpr bool value = false;
 };
 
 template <class T>
 struct has_foo<T, std::void_t<decltype(std::declval<T>().foo())>> {
-    inline constexpr bool value = true;
+    static constexpr bool value = true;
 };
 
 template <class T>


### PR DESCRIPTION
注意这里我们在讨论 C++17，类内的 `static` `constexpr` 成员已经蕴含了 `inline`，从而只需要写 `static` 即可。

Fixes #22.