### PR TITLE
fix setlocale bug on unicode.md

### DIFF
--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -2854,7 +2854,7 @@ int main() {
 #elif __unix__
     // 反正 Unix 系统默认都是 UTF-8，不设置也行，这里设置全局 locale 是为了让 iswspace 接受全角空格、iswpunct 接受全角逗号 L'，' 等
     //setlocale(LC_ALL, "zh_CN.utf-8"); // 设置使用中文本地化，可使 strerror 输出中文（但用户必须 locale-gen 过中文！）
-    setlocale(LC_ALL, "C.utf-8");     // 设置使用语言中性 locale（推荐），只影响 iswspace、iswpunct 等函数，不会使 strerror 等输出中文
+    setlocale(LC_ALL, "C.utf-8");       // 设置使用语言中性 locale（推荐），只影响 iswspace、iswpunct 等函数，不会使 strerror 等输出中文
 #endif
     // 这里开始写你的主程序吧！
     // ...

--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -2851,8 +2851,7 @@ int main() {
 #elif __unix__
     // 反正 Unix 系统默认都是 UTF-8，不设置也行，这里设置全局 locale 是为了让 iswspace 接受全角空格、iswpunct 接受全角逗号 L'，' 等
     //setlocale(LC_ALL, "zh_CN.utf-8"); // 设置使用中文本地化，可使 strerror 输出中文（但用户必须 locale-gen 过中文！）
-    //setlocale(LC_ALL, "C.utf-8");     // 设置使用语言中性 locale，只影响 iswspace、iswpunct 等函数，不会使 strerror 等输出中文
-    setlocale(LC_ALL, "");        // 若使用空字符串（推荐），则默认使用当前系统环境变量中的语言 $LANG，使 strerror 自动适应
+    setlocale(LC_ALL, "C.utf-8");     // 设置使用语言中性 locale（推荐），只影响 iswspace、iswpunct 等函数，不会使 strerror 等输出中文
 #endif
     // 这里开始写你的主程序吧！
     // ...

--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -2852,7 +2852,7 @@ int main() {
     // 反正 Unix 系统默认都是 UTF-8，不设置也行，这里设置全局 locale 是为了让 iswspace 接受全角空格、iswpunct 接受全角逗号 L'，' 等
     //setlocale(LC_ALL, "zh_CN.utf-8"); // 设置使用中文本地化，可使 strerror 输出中文（但用户必须 locale-gen 过中文！）
     //setlocale(LC_ALL, "C.utf-8");     // 设置使用语言中性 locale，只影响 iswspace、iswpunct 等函数，不会使 strerror 等输出中文
-    setlocale(LC_ALL, ".utf-8");        // 若不带任何前缀（推荐），则默认使用当前系统环境变量中的语言 $LANG，使 strerror 自动适应
+    setlocale(LC_ALL, "");        // 若使用空字符串（推荐），则默认使用当前系统环境变量中的语言 $LANG，使 strerror 自动适应
 #endif
     // 这里开始写你的主程序吧！
     // ...

--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -2848,6 +2848,9 @@ int main() {
     setlocale(LC_ALL, ".utf-8");  // 设置标准库调用系统 API 所用的编码，用于 fopen，ifstream 等函数
     SetConsoleOutputCP(CP_UTF8); // 设置控制台输出编码，或者写 system("chcp 65001") 也行，这里 CP_UTF8 = 65001
     SetConsoleCP(CP_UTF8); // 设置控制台输入编码，用于 std::cin
+#elif __APPLE__
+    // 通常来说 MacOS 的默认编码就是 UTF-8，这里设置全局 locale 是为了让 iswspace 接受全角空格、iswpunct 接受全角逗号 L'，' 等
+    setlocale(LC_ALL, "UTF-8");  // MacOS 设置 UTF-8 编码，让 iswspace 接受全角空格等
 #elif __unix__
     // 反正 Unix 系统默认都是 UTF-8，不设置也行，这里设置全局 locale 是为了让 iswspace 接受全角空格、iswpunct 接受全角逗号 L'，' 等
     //setlocale(LC_ALL, "zh_CN.utf-8"); // 设置使用中文本地化，可使 strerror 输出中文（但用户必须 locale-gen 过中文！）


### PR DESCRIPTION
`setlocale` 的 `.utf-8` 参数是 Windows 10 version 1803 (10.0.17134.0) 新加入的，不支持其他系统。这里提供一个[godbolt 链接](https://godbolt.org/z/h6G41bx4M)展示此问题。
对于 Unix-like 系统，由于其默认使用 UTF-8 编码，因此提供一个空字符串接受本地 locale 即可达到本地化的效果。

[Windows `.utf-8` 参考链接](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170)